### PR TITLE
Properly handle chardata return from IO.read

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.15.2-otp-26
+erlang 26.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2023-07-17
+### Fixed
+  - Properly handle the charlist return from `IO.read/2`
+
 ## [0.9.0] - 2023-07-17
 ### Changed
   - when a command is passed in that is not recognized, print help to the screen

--- a/lib/prompt/example.ex
+++ b/lib/prompt/example.ex
@@ -30,7 +30,7 @@ defmodule Prompt.Example.FallbackCommand do
   use Prompt.Command
 
   @impl true
-  def process(cmd) do
+  def process(_cmd) do
     display("fallback command")
   end
 end

--- a/lib/prompt/io/choice.ex
+++ b/lib/prompt/io/choice.ex
@@ -56,7 +56,8 @@ defmodule Prompt.IO.Choice do
       case read(:stdio, :line) do
         :eof -> :error
         {:error, _reason} -> :error
-        answer -> _evaluate_choice(answer, choice)
+        answer when is_binary(answer) -> _evaluate_choice(answer, choice)
+        answer when is_list(answer) -> _evaluate_choice(IO.chardata_to_string(answer), choice)
       end
     end
 

--- a/lib/prompt/io/confirm.ex
+++ b/lib/prompt/io/confirm.ex
@@ -77,12 +77,19 @@ defmodule Prompt.IO.Confirm do
         {:error, _reason} ->
           :error
 
-        answer ->
+        answer when is_binary(answer) ->
           if confirm.mask_line do
             Prompt.Position.mask_line(1)
           end
 
           evaluate_confirm(%{confirm | answer: answer})
+
+        answer when is_list(answer) ->
+          if confirm.mask_line do
+            Prompt.Position.mask_line(1)
+          end
+
+          evaluate_confirm(%{confirm | answer: IO.chardata_to_string(answer)})
       end
     end
 

--- a/lib/prompt/io/password.ex
+++ b/lib/prompt/io/password.ex
@@ -46,9 +46,16 @@ defmodule Prompt.IO.Password do
           write(IO.ANSI.reset())
           :error
 
-        answer ->
+        answer when is_binary(answer) ->
           write(IO.ANSI.reset())
           String.trim(answer)
+
+        answer when is_list(answer) ->
+          write(IO.ANSI.reset())
+
+          answer
+          |> IO.chardata_to_string()
+          |> String.trim()
       end
     end
 

--- a/lib/prompt/io/select.ex
+++ b/lib/prompt/io/select.ex
@@ -106,19 +106,29 @@ defmodule Prompt.IO.Select do
         {:error, reason} ->
           %Select{select | error: reason}
 
-        answer ->
+        answer when is_binary(answer) ->
           answer
           |> String.trim()
-          |> evaluate_choice_answer(select)
-          |> case do
-            %Select{error: err} = s when not is_nil(err) ->
-              s
-              |> show_select_error()
-              |> evaluate()
+          |> do_evaluate(select)
 
-            %Select{answer: answer} ->
-              answer
-          end
+        answer when is_list(answer) ->
+          answer
+          |> IO.chardata_to_string()
+          |> String.trim()
+          |> do_evaluate(select)
+      end
+    end
+
+    defp do_evaluate(answer, select) do
+      evaluate_choice_answer(answer, select)
+      |> case do
+        %Select{error: err} = s when not is_nil(err) ->
+          s
+          |> show_select_error()
+          |> evaluate()
+
+        %Select{answer: answer} ->
+          answer
       end
     end
 

--- a/lib/prompt/io/text.ex
+++ b/lib/prompt/io/text.ex
@@ -54,14 +54,24 @@ defmodule Prompt.IO.Text do
         {:error, _reason} ->
           :error
 
-        answer ->
-          answer = String.trim(answer)
+        answer when is_binary(answer) ->
+          answer
+          |> String.trim()
+          |> do_evaluate(txt)
 
-          case {determine_min(answer, txt), determine_max(answer, txt)} do
-            {false, _} -> :error_min
-            {true, false} -> :error_max
-            {true, true} -> answer
-          end
+        answer when is_list(answer) ->
+          answer
+          |> IO.chardata_to_string()
+          |> String.trim()
+          |> do_evaluate(txt)
+      end
+    end
+
+    defp do_evaluate(answer, txt) do
+      case {determine_min(answer, txt), determine_max(answer, txt)} do
+        {false, _} -> :error_min
+        {true, false} -> :error_max
+        {true, true} -> answer
       end
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Prompt.MixProject do
     [
       app: :prompt,
       description: "A terminal toolkit and a set of helpers for building console applications.",
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.10",
       package: package(),
       source_url: "https://github.com/silbermm/prompt",


### PR DESCRIPTION
It seems that with Elixir >= 1.15, the IO.read function returns a charlist instead of a string.

This fix adds a guard for each of the read operations for is_binary or is_list to deal with the return accordingly