### PR TITLE
Add tips for building with bakeware

### DIFF
--- a/lib/prompt.ex
+++ b/lib/prompt.ex
@@ -50,6 +50,8 @@ defmodule Prompt do
   For Bakeware, I also set `export RELEASE_DISTRIBUTION=none` in `rel/env.sh.eex` and `rel/env.bat.eex` - unless you need erlang distribution in your CLI.
 
   For a complete example see [Slim](https://github.com/silbermm/slim_pickens)
+
+  Run `MIX_ENV=prod mix release` to build the binary. This will output the usual release messages for a `mix release` command, but in the case of a CLI, it's a bit of a red herring. The binary you want to run as a CLI will be in `_build/prod/rel/bakeware/<your_app>`.
   """
 
   import IO
@@ -148,7 +150,7 @@ defmodule Prompt do
 
   will show "(y/n)" and return `:yes` or `:no` based on the choice.
 
-  Supported options: 
+  Supported options:
   #{NimbleOptions.docs(@choice_options)}
 
   ## Examples
@@ -420,8 +422,8 @@ defmodule Prompt do
 
       iex> Prompt.table([["Hello", "from", "the", "terminal!"],["this", "is", "another", "row"]], border: :none)
       "
-       Hello from the     terminal 
-       this  is   another row      
+       Hello from the     terminal
+       this  is   another row
       "
 
   """


### PR DESCRIPTION
Hey Matt!

First off, great library. I used it about a year ago to build a small CLI and it's a great design, docs, and API.

I'm making this pull request cause today I revisited the thing I built and needed to rebuild for an M1. I had a hell of a time figuring out how to run it after `mix release` and I think it would be helpful to add a note to the docs about where to find the thing that will actually take commands.

I was fumbling around with `_build/prod/rel/<myapp>/bin/<myapp> start <mycommand>` and `_build/prod/rel/<myapp>/bin/<myapp> eval "<mycommand>"`, and was pulling my hair out before realizing what I needed was in that `bakeware` directory.

Feel free to improve this or add more context. Honestly, I'm pretty out of practice with all things Elixir (:sosad:), so if there's something I'm missing please change it.

Cheers!